### PR TITLE
impl core::error::Error for error types

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,11 +1,13 @@
-use std::fmt::Display;
-
+use core::error::Error;
 use reqwest::{StatusCode, header::HeaderValue};
+use std::fmt::Display;
 
 #[derive(Debug)]
 pub enum EventError {
     IoError(std::io::Error),
 }
+
+impl Error for EventError {}
 
 impl Display for EventError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -22,6 +24,8 @@ pub enum EventSourceError {
     BadStatus(StatusCode),
     BadContentType(Option<HeaderValue>),
 }
+
+impl Error for EventSourceError {}
 
 impl Display for EventSourceError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {


### PR DESCRIPTION
Hello! Thanks for making this crate. I appreciate the minimalism and the flexibility it brings.

This tiny PR just adds a default implementation for the `core::error::Error` trait for the error types, so they can be composed with `thiserror` or `anyhow`, or treated as `Box<dyn Error>`, etc.