### PR TITLE
feat: handle crlf line endings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,7 +197,7 @@ impl EventSource for Response {
                     break;
                 }
                 let line = if let Some(line) = line_buffer.strip_suffix('\n') {
-                    line
+                    line.strip_suffix('\r').unwrap_or(line)
                 } else {
                     &line_buffer
                 };


### PR DESCRIPTION
Strips leading `\r` from line split to handle CLRF-encoded line endings properly.